### PR TITLE
Network printing requires Server Mode

### DIFF
--- a/content/docs/settings/devices/index.md
+++ b/content/docs/settings/devices/index.md
@@ -39,7 +39,7 @@ The label printing functionality is in an experimental state currently. There is
 
 #### Printing via Network
 
-<div class="note">Printing via network requires your Open mSupply instance to be running in <strong>server mode</strong>. If you are running in client mode, network printing will not work.</div>
+<div class="note">Printing via network requires either that your Open mSupply instance is running in <strong>server mode</strong> or that the network printer, the Open mSupply server and client are all on a local network.</div>
 
 Enter the IP address and other details of the printer. Click `Save` to save the details. Once saved, you can click the `Test` button to attempt to connect to the printer and fetch its configuration.
 


### PR DESCRIPTION
Add note to let users know that network printing requires OMS to be in Server Mode

<img width="1038" height="366" alt="Screenshot 2025-12-11 at 3 18 22 PM" src="https://github.com/user-attachments/assets/4e3fe7eb-5c67-441b-92c0-f1053b9ec131" />
