### PR TITLE
Add emergency requisitions documentation

### DIFF
--- a/content/docs/distribution/requisitions/index.md
+++ b/content/docs/distribution/requisitions/index.md
@@ -44,7 +44,7 @@ The list of Requisitions is divided into 6 columns:
 | **Shipments** | Number of shipments created from the requisition |
 | **Comment**   | Comment for the requisition                      |
 
-<div class="note">If you have program requisitions enabled, you may have additional columns in this table!</div>
+<div class="note">If you have program requisitions enabled, you may have additional columns in this table, including Program, Order Type and Period. Emergency orders are indicated with an emergency icon in the Order Type column, making it easy to identify and prioritise urgent requests from your customers.</div>
 
 ### Filter Requisitions
 
@@ -94,6 +94,10 @@ To view the detail of a particular requisition, simply click on it in the list v
 You will then see the detail view of the requisition:
 
 ![Requisition Detail](images/requisition-detail.png)
+
+<div class="tip">
+When a customer submits an emergency order, it will automatically appear in your Requisitions list flagged as an emergency. You can filter the list by order type to prioritise these urgent requests. Emergency orders typically contain a small number of critical items that need to be fulfilled promptly. See <a href="/docs/programs/requisitions/">Program Requisitions</a> for more details.
+</div>
 
 #### Enter a Customer Reference
 

--- a/content/docs/programs/Requisitions/index.md
+++ b/content/docs/programs/Requisitions/index.md
@@ -51,6 +51,22 @@ The programs and order period you see will be affected by the store tags and pro
 
 <div class="note">The program you select will affect which suppliers, order types and periods are available for selection</div>
 
+### Emergency Orders
+
+Emergency orders are designed for urgent, unplanned stock needs — for example, when a facility unexpectedly runs out of a critical medicine and cannot wait for the next scheduled ordering period. They allow facilities to quickly request a small number of essential items outside the normal ordering cycle.
+
+When selecting an **Order Type** in the creation dialog, emergency order types are displayed with a special emergency icon next to their name, making them easy to distinguish from normal order types.
+
+Unlike normal orders, emergency orders have a **maximum item limit**. This limit is configured per program and restricts how many different items you can include in a single emergency order.
+
+<div class="warning">
+If you try to add more items than the allowed maximum for an emergency order, the system will display an error message and prevent you from adding further items. This limit ensures that emergency orders remain focused on the most critical needs. If you need to order many items, a normal program order is more appropriate.
+</div>
+
+<div class="note">
+Not all programs support emergency orders. Whether an emergency order type is available depends on how the program has been configured on the central server. See the <a href="https://docs.msupply.org.nz/items:programs#creating_a_program">program configuration documentation</a> for details on setting up order types, including emergency orders and their item limits.
+</div>
+
 ## Differences when using program requisitions
 
 ### Internal Orders
@@ -125,8 +141,10 @@ The list view has gained some additional columns, showing the program related da
 ![Requisition: list](images/requisition-list.png)
 
 - **Program**: the name of the program this Internal Order was created for
-- **Order type**: the name of the order type ( typically, a normal or emergency order )
+- **Order type**: the name of the order type (e.g., Normal or Emergency). Emergency orders are indicated with an emergency icon, making them easy to identify at a glance
 - **Period**: the name of the period selected
+
+You can filter the requisition list by order type, which is useful for warehouse staff who want to quickly find and prioritise emergency orders from customers.
 
 #### Manual Program Requisitions
 

--- a/content/docs/replenishment/internal orders/index.md
+++ b/content/docs/replenishment/internal orders/index.md
@@ -39,6 +39,10 @@ You can use the filters to filter the list by the name, status, or requisition n
 
 ![Internal Order: filter](images/intord_filter.png)
 
+<div class="tip">
+If you are using program requisitions, additional filter options may be available, such as filtering by order type. This is helpful for quickly finding emergency orders. See <a href="/docs/programs/requisitions/">Program Requisitions</a> for full details on emergency orders.
+</div>
+
 You can sort the list using the column headers:
 
 1. Tap the column header of the column that you want to sort. The column is sorted in ascending order.


### PR DESCRIPTION
Document emergency orders as a feature of program-based requisitions, covering what they are, the item limit guardrail, how to identify them via the emergency icon, and how to filter for them in list views.

https://claude.ai/code/session_01LuJsE1Piw7oBCQy1E56P24