### PR TITLE
make compatible with zola version 22.1

### DIFF
--- a/.github/workflows/static_deploy.yml
+++ b/.github/workflows/static_deploy.yml
@@ -4,12 +4,12 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['main']
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -18,7 +18,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: 'pages'
+  group: "pages"
   cancel-in-progress: false
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Zola Build
-        uses: shalzz/zola-deploy-action@v0.19.2
+        uses: shalzz/zola-deploy-action@v0.22.1
         env:
           BUILD_DIR: .
           BUILD_ONLY: true
@@ -42,7 +42,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload public directory only
-          path: 'public/.'
+          path: "public/."
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ There is also a staging url, for staging for docs in 'staging' branch: https://d
 
 ## Getting Started
 
-This process has become slightly convoluted because zola to beginwith, but further because we use an outdated version of zola and installing it locally is no longer straightforward. We must use no more than version 17.2 of Zola, not 19.2 which is the latest as of writing.
-
 ### MacOS
 
 #### Install Github Desktop
@@ -28,18 +26,18 @@ Follow the prompts and let it clone the repo to your machine.
 <details>
 
 1. Clone Zola the same way as above with "Open in Github Desktop": https://github.com/getzola/zola
-2. In github desktop*, click on the "History" tab then scroll down and select the _commit_ that is tagged `v0.17.2`, right click and choose "Checkout Commit" ![image](https://github.com/user-attachments/assets/ec8cc390-c11f-49b4-bc61-2dda56957da1)
+2. In github desktop\*, click on the "History" tab then scroll down and select the _commit_ that is tagged `v0.22.1`, right click and choose "Checkout Commit" ![image](https://github.com/user-attachments/assets/ec8cc390-c11f-49b4-bc61-2dda56957da1)
 3. Install rust. You're a programmer Harry! https://www.rust-lang.org/tools/install
 4. Open a terminal in your Zola repo directory. You can do this in github desktop in the "Repository" Menu "Open in Terminal", or navigate a terminal window there if you're in the know.
 5. Run the command `cargo install --path . --locked` - this will use rust to build zola and install it
-6. Run `Zola --version` and pray that you are on `0.17.2`
+6. Run `Zola --version` and if it says 0.22.1 you're good to go!
 
-*Or cause you're a dev and cbf clicking around in github desktop just do:
+\*Or cause you're a dev and cbf clicking around in github desktop just do:
 
 ```shell
 git clone https://github.com/getzola/zola.git
 cd zola
-git checkout v0.17.2
+git checkout v0.22.1
 cargo install --path . --locked
 zola --version
 ```
@@ -48,11 +46,22 @@ zola --version
 
 #### Download Zola and Convince MacOS it is safe
 
-1. Download [the terminal executable program for your OS](https://github.com/getzola/zola/releases/download/v0.17.2/zola-v0.17.2-x86_64-apple-darwin.tar.gz) from https://github.com/getzola/zola/releases/tag/v0.17.2
+1. Download `zola-v0.22.1-x86_64-apple-darwin.tar.gz` from the [v0.22.1 release](https://github.com/getzola/zola/releases/tag/v0.22.1)
 2. Extract it and copy `zola` file to `/usr/local/bin/` (pressing `cmd+shift+.` in a finder window will toggle showing hidden folders 🙂)
-3. In a terminal try run `zola`. It'll complain about malware, at which point you can allow it in settings 
-![image](https://github.com/user-attachments/assets/6d9869d0-86e9-49e3-9e04-f35481a30d94)
-4. Run `zola --version` and if it says 0.17.2 you're good to go!
+3. In a terminal try run `zola`. It'll complain about malware, at which point you can allow it in settings
+   ![image](https://github.com/user-attachments/assets/6d9869d0-86e9-49e3-9e04-f35481a30d94)
+4. Run `zola --version` and if it says 0.22.1 you're good to go!
+
+#### To upgrade Zola
+
+If you already have Zola built from source, pull the latest and rebuild:
+
+```bash
+cd your_path/zola
+git fetch
+git checkout v0.22.1
+cargo install --path . --locked
+```
 
 #### Serve our docs with Zola!
 
@@ -71,4 +80,4 @@ If you wish to serve images from a subdirectory rather than co-locating the cont
 
 This repo is automatically deployed to github pages on push to main. The github action is defined in `.github/workflows/static_deploy.yml`
 
-The deployment code uses `zola 17.2`
+The deployment code uses `zola 0.22.1`

--- a/config.toml
+++ b/config.toml
@@ -53,11 +53,6 @@ flag = "pt.svg"
 TOCtitle = "Nesta página"
 search_placeholder = "Pesquisar documentos..."
 
-[markdown]
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
-
 [search]
 # Whether to include the title of the page/section in the index
 include_title = true


### PR DESCRIPTION
Made changes so this is compatible with zola version 22, prompted by changes here: https://github.com/msupply-foundation/open-msupply/pull/11285

I don't think there's any code blocks here for users? If needed, we can add the changes made in the above PR so that code blocks have syntax highlighting

Testing: 
Follow upgrade step in readme
Should be able to zola build/zola serve

The action is untested, is there a safe way to test that?